### PR TITLE
Setup keycloak to run on ovirt engine's wildfly instance

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,10 @@
+# outdir: passed by copr telling where to save the src.rpm
+# spec: passed by copr telling which spec file should be used;
+#       using for selecting the right src.rpm to be copied.
+
+installdeps:
+	dnf -y install coreutils curl dnf-utils findutils git rpmdevtools sed
+
+srpm: installdeps
+	automation/build-keycloak.sh
+	cp output/$(shell sh -c "basename '$(spec)'|cut -f1 -d.")*.src.rpm $(outdir)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 output
 *.zip
+*.tar.gz
+exported-artifacts
+rpmbuild
+
+# template generated resources
 ovirt-engine-keycloak.spec
+packaging/setup/ovirt_engine_setup/keycloak/config.py
+build/python-check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+output
+*.zip
+ovirt-engine-keycloak.spec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,189 @@
+# ====================================================================
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements.  See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ====================================================================
+#
+# This software consists of voluntary contributions made by many
+# individuals on behalf of the Apache Software Foundation.  For more
+# information on the Apache Software Foundation, please see
+# <http://www.apache.org/>.
+
+#
+# CUSTOMIZATION-BEGIN
+#
+# Keycloak version specification
+KEYCLOAK_VERSION="15.0.2"
+
+# RPM version specification
+RPM_VERSION="${KEYCLOAK_VERSION}"
+RPM_RELEASE="1"
+
+EXTRA_BUILD_FLAGS=
+BUILD_VALIDATION=1
+
+PACKAGE_NAME=ovirt-engine-keycloak
+
+PYTHON=$(shell which python3 2> /dev/null)
+PREFIX=/usr/local
+LOCALSTATE_DIR=$(PREFIX)/var
+BIN_DIR=$(PREFIX)/bin
+SYSCONF_DIR=$(PREFIX)/etc
+DATAROOT_DIR=$(PREFIX)/share
+DOC_DIR=$(DATAROOT_DIR)/doc
+PKG_DATA_DIR=$(DATAROOT_DIR)/ovirt-engine-keycloak
+PKG_SYSCONF_DIR=$(SYSCONF_DIR)/ovirt-engine-keycloak
+WILDFLY_DATA_DIR=$(DATAROOT_DIR)/ovirt-engine-wildfly
+HTTPD_SYSCONF_DIR=$(SYSCONF_DIR)/httpd
+PYTHON_DIR=$(PYTHON_SYS_DIR)
+DEV_PYTHON_DIR=
+PKG_USER=ovirt
+PKG_GROUP=ovirt
+KEYCLOAK_OVERLAY_ZIP="keycloak-overlay-$(KEYCLOAK_VERSION).zip"
+KEYCLOAK_OVERLAY_URL="https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/${KEYCLOAK_OVERLAY_ZIP}"
+#
+# CUSTOMIZATION-END
+#
+
+
+BUILD_FLAGS:=$(BUILD_FLAGS) $(EXTRA_BUILD_FLAGS)
+
+PYTHON_SYS_DIR:=$(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib as f;print(f())")
+
+TARBALL=$(PACKAGE_NAME)-$(RPM_VERSION).tar.gz
+BUILD_FILE=tmp.built
+
+
+.SUFFIXES:
+.SUFFIXES: .in
+
+.in:
+	sed \
+	-e "s|@KEYCLOAK_VERSION@|$(KEYCLOAK_VERSION)|g" \
+	-e "s|@KEYCLOAK_OVERLAY_ZIP@|$(KEYCLOAK_OVERLAY_ZIP)|g" \
+	-e "s|@PKG_USER@|$(PKG_USER)|g" \
+	-e "s|@PKG_GROUP@|$(PKG_GROUP)|g" \
+	-e "s|@DATAROOT_DIR@|$(DATAROOT_DIR)|g" \
+	-e "s|@PKG_SYSCONF_DIR@|$(PKG_SYSCONF_DIR)|g" \
+	-e "s|@PKG_DATA_DIR@|$(PKG_DATA_DIR)|g" \
+	-e "s|@PKG_STATE_DIR@|$(PKG_STATE_DIR)|g" \
+	-e "s|@DEV_PYTHON_DIR@|$(DEV_PYTHON_DIR)|g" \
+	-e "s|@RPM_VERSION@|$(RPM_VERSION)|g" \
+	-e "s|@RPM_RELEASE@|$(RPM_RELEASE)|g" \
+	-e "s|@PACKAGE_NAME@|$(PACKAGE_NAME)|g" \
+	-e "s|@KEYCLOAK_VERSION@|$(KEYCLOAK_VERSION)|g" \
+	-e "s|@KEYCLOAK_OVERLAY_PKG@|$(KEYCLOAK_OVERLAY_PKG)|g" \
+	-e "s|@PY_VERSION@|$(PY_VERSION)|g" \
+	-e "s|@HTTPD_SYSCONF_DIR@|$(HTTPD_SYSCONF_DIR)|g" \
+	-e "s|@WILDFLY_DATA_DIR@|$(WILDFLY_DATA_DIR)|g" \
+	$< > $@
+
+
+GENERATED = \
+	build/python-check.sh \
+	ovirt-engine-keycloak.spec \
+	packaging/setup/ovirt_engine_setup/keycloak/config.py \
+	$(NULL)
+
+
+all:	\
+	generated-files \
+	validations \
+	$(BUILD_FILE) \
+	$(NULL)
+
+generated-files:	$(GENERATED)
+	chmod a+x build/python-check.sh
+
+$(BUILD_FILE):
+	touch $(BUILD_FILE)
+
+clean:
+	rm -rf $(BUILD_FILE)
+	rm -rf tmp.dev.flist
+	rm -rf $(GENERATED)
+
+install: \
+	all \
+	install-packaging-files \
+	$(NULL)
+
+.PHONY: ovirt-engine-keycloak.spec.in
+
+
+dist:	ovirt-engine-keycloak.spec \
+	download-keycloak \
+	$(NULL)
+
+	git ls-files | tar --files-from /proc/self/fd/0 -czf \
+		"$(TARBALL)" \
+		ovirt-engine-keycloak.spec \
+		$(KEYCLOAK_OVERLAY_ZIP)
+	@echo
+	@echo For distro specific packaging refer to http://www.ovirt.org/Build_Binary_Package
+	@echo
+
+download-keycloak:
+	if [ ! -f "$(KEYCLOAK_OVERLAY_ZIP)" ]; then \
+		curl -L -o "$(KEYCLOAK_OVERLAY_ZIP)" "$(KEYCLOAK_OVERLAY_URL)"; \
+	fi
+
+# copy SOURCEDIR to TARGETDIR
+# exclude EXCLUDEGEN a list of files to exclude with .in
+# exclude EXCLUDE a list of files.
+copy-recursive:
+	( cd "$(SOURCEDIR)" && find . -type d -printf '%P\n' ) | while read d; do \
+		install -d -m 755 "$(TARGETDIR)/$${d}"; \
+	done
+	( \
+		cd "$(SOURCEDIR)" && find . -type f -printf '%P\n' | \
+		while read f; do \
+			exclude=false; \
+			for x in $(EXCLUDE_GEN); do \
+				if [ "$(SOURCEDIR)/$${f}" = "$${x}.in" ]; then \
+					exclude=true; \
+					break; \
+				fi; \
+			done; \
+			for x in $(EXCLUDE); do \
+				if [ "$(SOURCEDIR)/$${f}" = "$${x}" ]; then \
+					exclude=true; \
+					break; \
+				fi; \
+			done; \
+			$${exclude} || echo "$${f}"; \
+		done \
+	) | while read f; do \
+		src="$(SOURCEDIR)/$${f}"; \
+		dst="$(TARGETDIR)/$${f}"; \
+		[ -x "$${src}" ] && MASK=0755 || MASK=0644; \
+		[ -n "$(DEV_FLIST)" ] && echo "$${dst}" | sed 's#^$(PREFIX)/##' >> "$(DEV_FLIST)"; \
+		install -T -m "$${MASK}" "$${src}" "$${dst}"; \
+	done
+
+
+validations:	generated-files
+	if [ "$(BUILD_VALIDATION)" != 0 ]; then \
+		build/shell-check.sh && \
+		build/python-check.sh; \
+	fi
+
+install-packaging-files: \
+		$(GENERATED) \
+		$(NULL)
+	$(MAKE) copy-recursive SOURCEDIR=packaging/sys-etc TARGETDIR="$(DESTDIR)$(SYSCONF_DIR)" EXCLUDE_GEN="$(GENERATED)"
+	$(MAKE) copy-recursive SOURCEDIR=packaging/setup TARGETDIR="$(DESTDIR)$(PKG_DATA_DIR)/../ovirt-engine/setup" EXCLUDE_GEN="$(GENERATED)"
+	$(MAKE) copy-recursive SOURCEDIR=packaging/conf TARGETDIR="$(DESTDIR)$(PKG_DATA_DIR)/conf" EXCLUDE_GEN="$(GENERATED)"
+

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 
 Welcome to the ovirt-engine-keycloak source repository.
 
-This repository is hosted on [gerrit.ovirt.org:ovirt-engine-keycloak](https://gerrit.ovirt.org/#/admin/projects/ovirt-engine-keycloak)
-and a **backup** of it is hosted on [GitHub:ovirt-engine-keycloak](https://github.com/oVirt/ovirt-engine-keycloak)
-
 
 ## How to contribute
 

--- a/automation/build-artifacts-manual.packages
+++ b/automation/build-artifacts-manual.packages
@@ -1,0 +1,1 @@
+build-artifacts.packages

--- a/automation/build-artifacts-manual.sh
+++ b/automation/build-artifacts-manual.sh
@@ -1,0 +1,1 @@
+build-artifacts.sh

--- a/automation/build-artifacts-manual.sh
+++ b/automation/build-artifacts-manual.sh
@@ -1,1 +1,14 @@
-build-artifacts.sh
+#!/bin/sh -e
+
+automation/build-keycloak.sh
+
+# Build RPMs
+rpmbuild \
+    -D "_rpmdir $PWD/output" \
+    -D "_topdir $PWD/rpmbuild" \
+    --rebuild output/*.src.rpm
+
+# Store any relevant artifacts in exported-artifacts for the ci system to
+# archive
+[[ -d exported-artifacts ]] || mkdir -p exported-artifacts
+find output -iname \*rpm | xargs mv -t exported-artifacts

--- a/automation/build-artifacts.packages
+++ b/automation/build-artifacts.packages
@@ -3,6 +3,7 @@ curl
 dnf-utils
 findutils
 git
+make
+ovirt-engine-wildfly
 rpmdevtools
 sed
-ovirt-engine-wildfly

--- a/automation/build-artifacts.packages
+++ b/automation/build-artifacts.packages
@@ -1,0 +1,8 @@
+coreutils
+curl
+dnf-utils
+findutils
+git
+rpmdevtools
+sed
+ovirt-engine-wildfly

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+automation/build-keycloak.sh
+
+# Install any build requirements
+dnf builddep output/*src.rpm
+
+# Build RPMs
+rpmbuild \
+    -D "_rpmdir $PWD/output" \
+    -D "_topdir $PWD/rpmbuild" \
+    --rebuild output/*.src.rpm
+
+# Store any relevant artifacts in exported-artifacts for the ci system to
+# archive
+[[ -d exported-artifacts ]] || mkdir -p exported-artifacts
+find output -iname \*rpm | xargs mv -t exported-artifacts

--- a/automation/build-keycloak.sh
+++ b/automation/build-keycloak.sh
@@ -8,11 +8,11 @@ KEYCLOAK_VERSION="15.0.2"
 RPM_VERSION="${KEYCLOAK_VERSION}"
 RPM_RELEASE="1"
 
-# export KEYCLOAK_VERSION RPM_VERSION RPM_RELEASE
 
 # Cleanup
 rm -rf exported-artifacts
 rm -rf output
+make clean
 
 
 # The name and source of the package
@@ -20,25 +20,14 @@ name="ovirt-engine-keycloak"
 src="keycloak-overlay-$KEYCLOAK_VERSION.zip"
 url="https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-overlay-${KEYCLOAK_VERSION}.zip"
 
-# Download the source:
-if [ ! -f "${src}" ]
-then
-    curl -L -o "${src}" "${url}"
-fi
+[[ -d ${PWD}/rpmbuild/SOURCES ]] || mkdir -p ${PWD}/rpmbuild/SOURCES
 
-# Generate the spec from the template:
-sed \
-    -e "s/@VERSION@/${RPM_VERSION}/g" \
-    -e "s/@RELEASE@/${RPM_RELEASE}/g" \
-    -e "s/@SRC@/${src}/g" \
-    < "${name}.spec.in" \
-    > "${name}.spec"
+# Get the tarball
+make dist
 
 # Build the source and binary packages:
 rpmbuild \
-    -bs \
-    --define="_sourcedir ${PWD}" \
-    --define="_srcrpmdir ${PWD}/output" \
-    --define="_rpmdir ${PWD}" \
-    "${name}.spec"
-
+	-ts \
+	--define="_topdir ${PWD}/rpmbuild" \
+	--define="_srcrpmdir ${PWD}/output" \
+	"${name}-${RPM_VERSION}.tar.gz"

--- a/automation/build-keycloak.sh
+++ b/automation/build-keycloak.sh
@@ -1,0 +1,44 @@
+#!/bin/sh -e
+
+
+# Keycloak version specification
+KEYCLOAK_VERSION="15.0.2"
+
+# RPM version specification
+RPM_VERSION="${KEYCLOAK_VERSION}"
+RPM_RELEASE="1"
+
+# export KEYCLOAK_VERSION RPM_VERSION RPM_RELEASE
+
+# Cleanup
+rm -rf exported-artifacts
+rm -rf output
+
+
+# The name and source of the package
+name="ovirt-engine-keycloak"
+src="keycloak-overlay-$KEYCLOAK_VERSION.zip"
+url="https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_VERSION}/keycloak-overlay-${KEYCLOAK_VERSION}.zip"
+
+# Download the source:
+if [ ! -f "${src}" ]
+then
+    curl -L -o "${src}" "${url}"
+fi
+
+# Generate the spec from the template:
+sed \
+    -e "s/@VERSION@/${RPM_VERSION}/g" \
+    -e "s/@RELEASE@/${RPM_RELEASE}/g" \
+    -e "s/@SRC@/${src}/g" \
+    < "${name}.spec.in" \
+    > "${name}.spec"
+
+# Build the source and binary packages:
+rpmbuild \
+    -bs \
+    --define="_sourcedir ${PWD}" \
+    --define="_srcrpmdir ${PWD}/output" \
+    --define="_rpmdir ${PWD}" \
+    "${name}.spec"
+

--- a/automation/build-srpms.sh
+++ b/automation/build-srpms.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+# Keycloak version specification
+KEYCLOAK_VERSION="15.0.2"
+
+# RPM version specification
+RPM_VERSION="${KEYCLOAK_VERSION}"
+RPM_RELEASE="1"
+
+export KEYCLOAK_VERSION RPM_VERSION RPM_RELEASE
+
+# Cleanup
+rm -rf exported-artifacts
+rm -rf output
+
+# Build SRPMs
+automation/build-keycloak.sh

--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -1,0 +1,1 @@
+build-artifacts.packages

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -1,0 +1,1 @@
+build-artifacts.sh

--- a/build/python-check.sh.in
+++ b/build/python-check.sh.in
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+PEP8="@PEP8@"
+PYFLAKES="@PYFLAKES@"
+SRCDIR="$(dirname "$0")/.."
+
+cd "${SRCDIR}"
+
+ret=0
+FILES="$(
+	find build packaging -name '*.py' | while read f; do
+		[ -e "${f}.in" ] || echo "${f}"
+	done
+)"
+
+for exe in "${PYFLAKES}" "${PEP8}"; do
+	if ! which "${exe}" > /dev/null 2>&1; then
+		echo "WARNING: tool '${exe}' is missing" >&2
+	else
+		"${exe}" ${FILES} || ret=1
+	fi
+done
+exit ${ret}

--- a/build/shell-check.sh
+++ b/build/shell-check.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+SRCDIR="$(dirname "$0")/.."
+cd "${SRCDIR}"
+
+if [ -z "${VALIDATION_SHELL}" ]; then
+	# prefer dash over bash for POSIX complaint
+	[ -x /bin/dash ] && VALIDATION_SHELL="/bin/dash" || VALIDATION_SHELL="/bin/sh"
+fi
+
+EXTRA_ARGS=""
+# if bash use POSIX parsing
+"${VALIDATION_SHELL}" --version 2>&1 | grep -q bash && EXTRA_ARGS="${EXTRA_ARGS} --posix"
+
+ret="$(
+	find packaging build -type f \( -executable -or -name '*.sh' -or -name '*.bash' \) -and -not -name '*.py' | while read f; do
+		read l < "${f}"
+		shell="/bin/sh"
+		candidate="${l#\#!}"
+		candidate="${candidate# *}" # remove leading spaces
+		candidate="${candidate% *}" # remove parameter
+		[ "${candidate}" != "${l}" ] && shell="${candidate}"
+		skip=
+		case "${shell}" in
+			/bin/sh) shell="${VALIDATION_SHELL} ${EXTRA_ARGS}" ;;
+			/bin/bash) ;;
+			/usr/bin/python*) skip=1 ;;
+			*)
+				echo "ERROR: Unknown shell '${shell}' for '${f}'"
+				ret=1
+			;;
+		esac
+		if [ -z "${skip}" ]; then
+			${shell} -n "${f}" || ret=1
+		fi
+		echo "${ret}"
+	done | tail -n 1
+)"
+
+exit ${ret}

--- a/ovirt-engine-keycloak.spec.in
+++ b/ovirt-engine-keycloak.spec.in
@@ -1,0 +1,40 @@
+%global __jar_repack 0
+
+Name:		ovirt-engine-keycloak
+Version:	@VERSION@
+Release:	@RELEASE@%{?dist}
+Summary:	Keycloak SSO for oVirt Engine
+Group:		Virtualization/Management
+License:	ASL 2.0
+URL:		http://keycloak.org
+BuildArch:	noarch
+Source:		@SRC@
+Source1:	README.md
+
+BuildRequires:	curl
+BuildRequires:	unzip
+
+Requires: ovirt-engine-wildfly
+
+
+%description
+Keycloak SSO for oVirt Engine.
+
+
+%install
+mkdir -p %{buildroot}%{_datadir}
+unzip -d %{buildroot}%{_datadir}/%{name} %{SOURCE0}
+
+install -d -m 0755 "%{buildroot}%{_docdir}/%{name}"
+install -m 0644 "%{SOURCE1}" "%{buildroot}%{_docdir}/%{name}/README.md"
+install -d -m 0755 "%{buildroot}%{_datadir}/%{name}/modules"
+
+%files
+%{_datadir}/%{name}/
+%{_docdir}/%{name}/
+
+
+%changelog
+* Wed Nov 10 2021 Artur Socha <asocha@redhat.com> 15.0.2-1
+- Initial release
+

--- a/ovirt-engine-keycloak.spec.in
+++ b/ovirt-engine-keycloak.spec.in
@@ -1,37 +1,138 @@
 %global __jar_repack 0
 
+%global product_name Keycloak SSO for oVirt Engine
+
+%global engine_gid 108
+%global engine_group ovirt
+%global engine_uid 108
+%global engine_user ovirt
+
+# Macro to create an user:
+#
+# %1 user name
+# %2 user id
+# %3 primary group name
+# %4 primary group id
+# %5 description
+# %6 home directory
+#
+%global _ovirt_create_user() \
+getent group %3 >/dev/null || groupadd -r -g %4 %3; \
+getent passwd %1 >/dev/null || useradd -r -u %2 -g %3 -c %5 -s /sbin/nologin -d %6 %1
+
+%global ovirt_create_user_engine \
+%_ovirt_create_user %{engine_user} %{engine_uid} %{engine_group} %{engine_gid} "%%{ovirt_user_description}" %{engine_state}
+
+%global make_common_opts \\\
+	-j1 \\\
+	BUILD_VALIDATION=0 \\\
+	PACKAGE_NAME=%{name} \\\
+	RPM_VERSION=%{version} \\\
+	RPM_RELEASE=%{release} \\\
+	LOCALSTATE_DIR=%{_localstatedir} \\\
+	PREFIX=%{_prefix} \\\
+	SYSCONF_DIR=%{_sysconfdir} \\\
+	BIN_DIR=%{_bindir} \\\
+	DATAROOT_DIR=%{_datadir} \\\
+	MAN_DIR=%{_mandir} \\\
+	DOC_DIR=%{_docdir} \\\
+	PYTHON=%{__python3} \\\
+	PYTHON_DIR=%{python3_sitelib} \\\
+	PKG_USER=%{engine_user} \\\
+	PKG_GROUP=%{engine_group} \\\
+	%{?EXTRA_BUILD_FLAGS:EXTRA_BUILD_FLAGS="%{EXTRA_BUILD_FLAGS}"}
+
+
+
+########################################################
+#  Keycloak overlay package
+########################################################
 Name:		ovirt-engine-keycloak
-Version:	@VERSION@
-Release:	@RELEASE@%{?dist}
-Summary:	Keycloak SSO for oVirt Engine
+Version:	@RPM_VERSION@
+Release:	@RPM_RELEASE@%{?dist}
+Summary:	%{product_name}
 Group:		Virtualization/Management
 License:	ASL 2.0
 URL:		http://keycloak.org
 BuildArch:	noarch
-Source:		@SRC@
-Source1:	README.md
+Source:		%{name}-@RPM_VERSION@.tar.gz
 
 BuildRequires:	curl
 BuildRequires:	unzip
 
-Requires: ovirt-engine-wildfly
-
+Requires:	ovirt-engine-wildfly
 
 %description
 Keycloak SSO for oVirt Engine.
 
+########################################################
+#  Keycloak overlay setup package
+########################################################
+%package setup
+Summary:	%{product_name} setup
+Group:		Virtualization/Management
+Requires:	ovirt-engine-setup-plugin-ovirt-engine-common >= 4.4.0
+BuildRequires:	python3
+BuildRequires:	python3-devel
+Requires: python%{python3_pkgversion}-ovirt-setup-lib
+Requires:	%{name} >= %{version}
+
+%description setup
+Keycloak SSO for oVirt Engine installation setup package.
+
+
+########################################################
+#  Package customizations
+########################################################
+%pre
+%ovirt_create_user_engine
+
+%prep
+%setup -cq
+
+%build
+make %{make_common_opts}
 
 %install
-mkdir -p %{buildroot}%{_datadir}
-unzip -d %{buildroot}%{_datadir}/%{name} %{SOURCE0}
+rm -fr "%{buildroot}"
+make %{make_common_opts} install DESTDIR=%{buildroot}
 
+# Unzip downloaded keycloak overlay package
+mkdir -p %{buildroot}%{_datadir}
+unzip -d %{buildroot}%{_datadir}/%{name} @KEYCLOAK_OVERLAY_ZIP@
+
+# install Readme
 install -d -m 0755 "%{buildroot}%{_docdir}/%{name}"
-install -m 0644 "%{SOURCE1}" "%{buildroot}%{_docdir}/%{name}/README.md"
-install -d -m 0755 "%{buildroot}%{_datadir}/%{name}/modules"
+install -m 0644 "%{_builddir}/%{name}-%{version}/README.md" "%{buildroot}%{_docdir}/%{name}/README.md"
+
+# prepare sym links from ovirt-engine-wildfly to relevant ovirt-engine-keycloak artifacts
+# that is required because keycloak overlay is supposed to be extracted inside Wildfly/EAP location
+# and for ease of future management we do not want to mix them, symlinks here is an acceptable trade off
+mkdir -p %{buildroot}%{_datadir}/ovirt-engine-wildfly/modules/system/layers
+ln -sf %{_datadir}/%{name}/themes %{buildroot}%{_datadir}/ovirt-engine-wildfly/themes
+ln -sf %{_datadir}/%{name}/modules/layers.conf %{buildroot}%{_datadir}/ovirt-engine-wildfly/modules/layers.conf
+ln -sf %{_datadir}/%{name}/modules/system/layers/keycloak %{buildroot}%{_datadir}/ovirt-engine-wildfly/modules/system/layers/keycloak
+
+mkdir -p %{buildroot}%{_datadir}/ovirt-engine-wildfly/bin/client
+ln -sf %{_datadir}/%{name}/bin/add-user-keycloak.sh %{buildroot}%{_datadir}/ovirt-engine-wildfly/bin/add-user-keycloak.sh
+ln -sf %{_datadir}/%{name}/bin/client/keycloak-admin-cli-@KEYCLOAK_VERSION@.jar %{buildroot}%{_datadir}/ovirt-engine-wildfly/bin/client/keycloak-admin-cli-@KEYCLOAK_VERSION@.jar
+ln -sf %{_datadir}/%{name}/bin/client/keycloak-client-registration-cli-@KEYCLOAK_VERSION@.jar %{buildroot}%{_datadir}/ovirt-engine-wildfly/bin/client/keycloak-client-registration-cli-@KEYCLOAK_VERSION@.jar
+
 
 %files
 %{_datadir}/%{name}/
+%{_datadir}/ovirt-engine-wildfly/modules/layers.conf
+%{_datadir}/ovirt-engine-wildfly/modules/system/layers/keycloak
+%{_datadir}/ovirt-engine-wildfly/themes
+%{_datadir}/ovirt-engine-wildfly/bin/client/keycloak-admin-cli-@KEYCLOAK_VERSION@.jar
+%{_datadir}/ovirt-engine-wildfly/bin/client/keycloak-client-registration-cli-@KEYCLOAK_VERSION@.jar
+%{_datadir}/ovirt-engine-wildfly/bin/add-user-keycloak.sh
 %{_docdir}/%{name}/
+
+%files setup
+%{_datadir}/ovirt-engine/setup/ovirt_engine_setup/keycloak/
+%{_datadir}/ovirt-engine/setup/plugins/*/ovirt-engine-keycloak/apache
+%{_datadir}/ovirt-engine/setup/plugins/*/ovirt-engine-keycloak/ovirt-engine
 
 
 %changelog

--- a/packaging/conf/z-ovirt-engine-keycloak-proxy.conf.in
+++ b/packaging/conf/z-ovirt-engine-keycloak-proxy.conf.in
@@ -1,0 +1,44 @@
+#
+# The name of this file name is very important, the "z-" prefix is used
+# to force the web server to load this file after all the other
+# configurations, in particular after the configuration of the required
+# proxy modules, otherwise the "IfModule" directives fail.
+#
+
+<IfModule !proxy_ajp_module>
+    # If you get an error in this block, it means that proxy_ajp_module is not:
+    # 1. loaded by other configuration of httpd
+    # 2. found in the path below (which is relative to ServerRoot)
+    LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+</IfModule>
+
+<IfModule proxy_ajp_module>
+
+    #
+    # Remove the Expect headers from API requests (this is needed to fix a
+    # problem with some API clients):
+    #
+    # This is required because otherwise Expect header, which is hop-by-hop
+    # will be caught by the Apache and will NOT be forwared to the proxy.
+    #
+    # It currenly is used here, which means GLOBALLY for the server. It is done
+    # this way because RequestHeader 'early' doesn't allow using in either
+    # 'Directory' or 'Location' nested clauses.
+    #
+    # TODO: find a way to filter Expect headers for /api name space only.
+    <IfModule headers_module>
+        RequestHeader unset Expect early
+    </IfModule>
+
+
+    # pass calls to keycloak endoint
+    <LocationMatch ^/auth($|/)>
+        ProxyPassMatch ajp://127.0.0.1:@JBOSS_AJP_PORT@ timeout=3600 retry=5
+
+        <IfModule deflate_module>
+            AddOutputFilterByType DEFLATE text/javascript text/css text/html text/xml text/json application/xml application/json application/x-yaml
+        </IfModule>
+    </LocationMatch>
+
+</IfModule>
+

--- a/packaging/setup/ovirt_engine_setup/keycloak/__init__.py
+++ b/packaging/setup/ovirt_engine_setup/keycloak/__init__.py
@@ -1,0 +1,16 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""ovirt_engine_setup module."""
+
+
+__all__ = []
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/ovirt_engine_setup/keycloak/config.py.in
+++ b/packaging/setup/ovirt_engine_setup/keycloak/config.py.in
@@ -1,0 +1,15 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""Config."""
+
+PKG_SYSCONF_DIR = '@PKG_SYSCONF_DIR@'
+PKG_DATA_DIR = '@PKG_DATA_DIR@'
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/ovirt_engine_setup/keycloak/constants.py
+++ b/packaging/setup/ovirt_engine_setup/keycloak/constants.py
@@ -1,0 +1,73 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""Constants."""
+
+
+import gettext
+import os
+
+from otopi import util
+
+from ovirt_engine_setup.constants import osetupattrsclass
+from ovirt_engine_setup.engine import constants as oenginecons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+
+from . import config
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-setup')
+
+
+@util.export
+@util.codegen
+class Const(object):
+    SERVICE_NAME = 'grafana-server'
+    OVIRT_ENGINE_KEYCLOAK_SETUP_PACKAGE_NAME = \
+        'ovirt-engine-keycloak'
+
+
+@util.export
+@util.codegen
+@osetupattrsclass
+class ApacheEnv(object):
+    HTTPD_CONF_OVIRT_ENGINE_KEYCLOAK = 'OVESETUP_APACHE/configFileOvirtEngineKeycloak'
+
+
+@util.export
+@util.codegen
+class FileLocations(oengcommcons.FileLocations):
+    SYSCONFDIR = '/etc'
+    LOCALSTATEDIR = '/var'
+    DATADIR = '/usr/share'
+    PKG_DATA_DIR = config.PKG_DATA_DIR
+
+    DIR_HTTPD = os.path.join(
+        SYSCONFDIR,
+        'httpd',
+    )
+
+    HTTPD_CONF_OVIRT_ENGINE_KEYCLOAK = os.path.join(
+        DIR_HTTPD,
+        'conf.d',
+        'z-ovirt-engine-keycloak-proxy.conf'
+    )
+
+    HTTPD_CONF_OVIRT_ENGINE_KEYCLOAK_TEMPLATE = os.path.join(
+        PKG_DATA_DIR,
+        'conf',
+        'z-ovirt-engine-keycloak-proxy.conf.in',
+    )
+
+    OVIRT_ENGINE_SERVICE_CONFIG_KEYCLOAK = os.path.join(
+        oenginecons.FileLocations.OVIRT_ENGINE_SERVICE_CONFIGD,
+        '12-keycloak-config.conf'
+    )
+
+

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/apache/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/apache/__init__.py
@@ -1,0 +1,20 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+from otopi import util
+
+
+from . import keycloakproxy
+
+
+@util.export
+def createPlugins(context):
+    keycloakproxy.Plugin(context=context)
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/apache/keycloakproxy.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/apache/keycloakproxy.py
@@ -1,0 +1,75 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+"""keycloak httpd proxy plugin."""
+
+import gettext
+
+from otopi import constants as otopicons
+from otopi import filetransaction
+from otopi import plugin
+from otopi import util
+from ovirt_engine import util as outil
+from ovirt_engine_setup import constants as osetupcons
+from ovirt_engine_setup.engine import constants as oenginecons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+from ovirt_engine_setup.keycloak import constants as okkcons
+
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-keycloak')
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """keycloak httpd proxy plugin."""
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_INIT,
+    )
+    def _init(self):
+        self.environment.setdefault(
+            okkcons.ApacheEnv.HTTPD_CONF_OVIRT_ENGINE_KEYCLOAK,
+            okkcons.FileLocations.HTTPD_CONF_OVIRT_ENGINE_KEYCLOAK
+        )
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_MISC,
+        condition=lambda self: self.environment[
+                                   oenginecons.CoreEnv.ENABLE
+                               ] and not self.environment[
+            osetupcons.CoreEnv.DEVELOPER_MODE
+        ],
+    )
+    def _httpd_keycloak_misc(self):
+        self.environment[oengcommcons.ApacheEnv.NEED_RESTART] = True
+        self.environment[otopicons.CoreEnv.MAIN_TRANSACTION].append(
+            filetransaction.FileTransaction(
+                name=self.environment[
+                    okkcons.ApacheEnv.HTTPD_CONF_OVIRT_ENGINE_KEYCLOAK
+                ],
+                content=outil.processTemplate(
+                    template=(
+                        okkcons.FileLocations.HTTPD_CONF_OVIRT_ENGINE_KEYCLOAK_TEMPLATE
+                    ),
+                    subst={
+                        '@JBOSS_AJP_PORT@': self.environment[
+                            oengcommcons.ConfigEnv.JBOSS_AJP_PORT
+                        ],
+                    },
+                ),
+                modifiedList=self.environment[
+                    otopicons.CoreEnv.MODIFIED_FILES
+                ],
+            )
+        )
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/ovirt-engine/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/ovirt-engine/__init__.py
@@ -1,0 +1,20 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+from otopi import util
+
+
+from . import keycloak
+
+
+@util.export
+def createPlugins(context):
+    keycloak.Plugin(context=context)
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/ovirt-engine/keycloak.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/ovirt-engine/keycloak.py
@@ -1,0 +1,69 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""keycloak plugin."""
+
+
+import gettext
+
+from otopi import constants as otopicons
+from otopi import filetransaction
+from otopi import plugin
+from otopi import util
+
+
+from ovirt_engine_setup.engine import constants as oenginecons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+from ovirt_engine_setup.keycloak import constants as okkcons
+
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-setup')
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """keycloak plugin."""
+
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_SETUP,
+    )
+    def _setup(self):
+        self.environment[oengcommcons.ConfigEnv.JAVA_NEEDED] = True
+        self.environment[oengcommcons.ConfigEnv.JBOSS_NEEDED] = True
+
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_MISC,
+        after=(
+                oengcommcons.Stages.DB_CONNECTION_AVAILABLE,
+        ),
+        condition=lambda self: self.environment[oenginecons.CoreEnv.ENABLE],
+    )
+    def _misc(self):
+        content = [
+            'KEYCLOAK_BUNDLED=true',
+        ]
+        self.environment[otopicons.CoreEnv.MAIN_TRANSACTION].append(
+            filetransaction.FileTransaction(
+                name=okkcons.FileLocations.OVIRT_ENGINE_SERVICE_CONFIG_KEYCLOAK,
+                content=content,
+                modifiedList=self.environment[
+                    otopicons.CoreEnv.MODIFIED_FILES
+                ],
+            )
+        )
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,0 +1,6 @@
+distros:
+  - el8
+
+release_branches:
+  master:
+    - ovirt-master


### PR DESCRIPTION
This is initial  support for running Keycloak on top of oVirt Engine's Wildfly. 
Currently keycloak app is deployed with all the default settings under https://<engine-host>:<port>/auth.
