### PR TITLE
Remove plain passwords from setup log file

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/core/misc.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/core/misc.py
@@ -9,13 +9,12 @@
 
 import gettext
 
-
+from otopi import constants as otopicons
 from otopi import util
 from otopi import plugin
 
 from ovirt_engine import configfile
 from ovirt_engine_setup import constants as osetupcons
-from ovirt_engine_setup.engine import constants as oenginecons
 from ovirt_engine_setup.keycloak import constants as okkcons
 
 
@@ -29,6 +28,37 @@ class Plugin(plugin.PluginBase):
     def __init__(self, context):
         super(Plugin, self).__init__(context=context)
 
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_BOOT,
+        before=(
+            osetupcons.Stages.SECRETS_FILTERED_FROM_SETUP_ATTRS_MODULES,
+        ),
+    )
+    def _boot(self):
+        self.environment[
+            otopicons.CoreEnv.LOG_FILTER_KEYS
+        ].append(
+            "QUESTION/1/OVESETUP_CONFIG_ADMIN_SETUP"
+        )
+        self.environment[
+            otopicons.CoreEnv.LOG_FILTER_KEYS
+        ].append(
+            "QUESTION/2/OVESETUP_CONFIG_ADMIN_SETUP"
+        )
+
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_INIT,
+    )
+    def _init(self):
+        self.environment[
+            osetupcons.CoreEnv.SETUP_ATTRS_MODULES
+        ].append(
+            okkcons,
+        )
+
+
     @plugin.event(
         stage=plugin.Stages.STAGE_SETUP,
     )
@@ -41,11 +71,6 @@ class Plugin(plugin.PluginBase):
             optional=True,
         )
 
-        self.environment[
-            osetupcons.CoreEnv.SETUP_ATTRS_MODULES
-        ].append(
-            okkcons,
-        )
 
     @plugin.event(
         stage=plugin.Stages.STAGE_INIT,


### PR DESCRIPTION
This patch makes sure that passwords provided via answer files are not
printed in plain text in setup log.

Additionally, keycloak constants file is imported earlier so that
annotations were parsed in earlier stage.

Signed-off-by: Artur Socha <asocha@redhat.com>