### PR TITLE
Secure keycloak CLI tools wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ install-packaging-files: \
 		$(NULL)
 	$(MAKE) copy-recursive SOURCEDIR=packaging/setup TARGETDIR="$(DESTDIR)$(PKG_DATA_DIR)/../ovirt-engine/setup" EXCLUDE_GEN="$(GENERATED)"
 	$(MAKE) copy-recursive SOURCEDIR=packaging/conf TARGETDIR="$(DESTDIR)$(PKG_DATA_DIR)/conf" EXCLUDE_GEN="$(GENERATED)"
+	$(MAKE) copy-recursive SOURCEDIR=packaging/bin TARGETDIR="$(DESTDIR)$(PKG_DATA_DIR)/bin" EXCLUDE_GEN="$(GENERATED)"
 
 install-layout:
 	install -dm 755 "$(DESTDIR)$(PKG_STATE_DIR)/backups" \

--- a/packaging/bin/kk_cli.sh
+++ b/packaging/bin/kk_cli.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [[ ! -z ${ADMIN_PASSWORD} ]]; then
+  # handle kcadm config credentials
+  ${KK_TOOL} $* --password $ADMIN_PASSWORD
+elif [[ ! -z ${USER_NEW_PASSWORD} ]]; then
+  # handle kcadm set-password for user
+  ${KK_TOOL} $* --new-password $USER_NEW_PASSWORD
+elif [[ !  -z ${CLIENT_SECRET} ]]; then
+  # handle kcadm client create
+  ${KK_TOOL} $* -s secret=$CLIENT_SECRET
+else
+  ${KK_TOOL} $*
+fi
+

--- a/packaging/setup/ovirt_engine_setup/keycloak/constants.py
+++ b/packaging/setup/ovirt_engine_setup/keycloak/constants.py
@@ -157,6 +157,7 @@ class ConfigEnv(object):
 
     KEYCLOAK_ADD_USER_SCRIPT = 'OVESETUP_KEYCLOAK_CONFIG/addUserKeycloakScript'
     KEYCLOAK_CLI_ADMIN_SCRIPT = 'OVESETUP_KEYCLOAK_CONFIG/kcadmScript'
+    KEYCLOAK_WRAPPER_SCRIPT = 'OVESETUP_KEYCLOAK_CONFIG/kkWrapperScript'
     KEYCLOAK_AUTH_URL = 'OVESETUP_KEYCLOAK_CONFIG/authUrl'
     KEYCLOAK_TOKEN_URL = 'OVESETUP_KEYCLOAK_CONFIG/tokenUrl'
     KEYCLOAK_USERINFO_URL = 'OVESETUP_KEYCLOAK_CONFIG/userinfoUrl'
@@ -336,6 +337,12 @@ class FileLocations(oesetupcons.FileLocations):
         PKG_DATA_DIR,
         'conf',
         'internalsso-openidc.conf.in',
+    )
+
+    KEYCLOAK_WRAPPER_SCRIPT = os.path.join(
+        PKG_DATA_DIR,
+        'bin',
+        'kk_cli.sh'
     )
 
     OVIRT_ENGINE_SERVICE_CONFIG_KEYCLOAK = os.path.join(

--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/core/admin_user.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/core/admin_user.py
@@ -45,6 +45,11 @@ class Plugin(plugin.PluginBase):
                 okkcons.Const.KEYCLOAK_ADD_USER_SCRIPT,
             ),
         )
+        self.environment.setdefault(
+            okkcons.ConfigEnv.KEYCLOAK_WRAPPER_SCRIPT,
+            okkcons.FileLocations.KEYCLOAK_WRAPPER_SCRIPT,
+        )
+
 
     @plugin.event(
         stage=plugin.Stages.STAGE_MISC,
@@ -77,17 +82,20 @@ class Plugin(plugin.PluginBase):
             self.execute(
                 args=(
                     self.environment[
-                        okkcons.ConfigEnv.KEYCLOAK_ADD_USER_SCRIPT
+                        okkcons.ConfigEnv.KEYCLOAK_WRAPPER_SCRIPT
                     ],
                     '-r', okkcons.Const.KEYCLOAK_MASTER_REALM,
                     '-u', self.environment[
                         oenginecons.ConfigEnv.ADMIN_USER
                     ].rsplit('@', 1)[0],
-                     '--sc', okkcons.FileLocations.OVIRT_ENGINE_CONFIG_DIR,
-                     '-p', password,
+                    '--sc', okkcons.FileLocations.OVIRT_ENGINE_CONFIG_DIR,
                 ),
                 envAppend={
                     'JAVA_OPTS': '-Dcom.redhat.fips=false',
+                    'ADMIN_PASSWORD': password,
+                    'KK_TOOL': self.environment[
+                        okkcons.ConfigEnv.KEYCLOAK_ADD_USER_SCRIPT
+                    ]
                 },
             )
             os.chown(


### PR DESCRIPTION
This PR contains a wrapper scripts that overcome an issue with passwords/credentials being passed as command parameters so that these passwords could not be scraped from 'ps' output.

Additionally this will random issues found on OST when, for some unknown reason, 'stdin' passwords are not available (happens occasionally) 