### PR TITLE
Minor keycloak setup fixes

### DIFF
--- a/ovirt-engine-keycloak.spec.in
+++ b/ovirt-engine-keycloak.spec.in
@@ -53,7 +53,7 @@ BuildRequires:	python3
 BuildRequires:	python3-devel
 
 Requires:	%{name} >= 15.0.2
-Requires:	ovirt-engine-setup-plugin-ovirt-engine-common >= 4.5.0
+Requires:	ovirt-engine-setup-plugin-ovirt-engine >= 4.5.0
 Requires:	python%{python3_pkgversion}-ovirt-setup-lib
 
 %description setup

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/core/misc.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/core/misc.py
@@ -38,6 +38,7 @@ class Plugin(plugin.PluginBase):
             oenginecons.Stages.OVN_PROVIDER_CREDENTIALS_CUSTOMIZATION,
         ),
         after=(
+            oenginecons.Stages.CORE_ENABLE,
             osetupcons.Stages.DIALOG_TITLES_S_PRODUCT_OPTIONS,
         ),
         condition=lambda self: (


### PR DESCRIPTION
This patch fixes the order of keycloak 'enable' stage to happen after
'engine enabled'.

Additionally, ovirt-engine-keycloak-setup depends on
ovirt-engine-setup-plugin-ovirt-engine instead of only
ovirt-engine-setup-plugin-ovirt-engine-common

Signed-off-by: Artur Socha <asocha@redhat.com>
