### PR TITLE
Register keycloak attrs  at STAGE_BOOT

### DIFF
--- a/packaging/setup/ovirt_engine_setup/keycloak/constants.py
+++ b/packaging/setup/ovirt_engine_setup/keycloak/constants.py
@@ -281,7 +281,6 @@ class ProvisioningEnv(object):
     @osetupattrs(
         answerfile=True,
         summary=True,
-        is_secret=True,
         description=_('Configure local Keycloak database'),
     )
     def POSTGRES_PROVISIONING_ENABLED(self):

--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/core/misc.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/core/misc.py
@@ -37,6 +37,11 @@ class Plugin(plugin.PluginBase):
     )
     def _boot(self):
         self.environment[
+            osetupcons.CoreEnv.SETUP_ATTRS_MODULES
+        ].append(
+            okkcons,
+        )
+        self.environment[
             otopicons.CoreEnv.LOG_FILTER_KEYS
         ].append(
             "QUESTION/1/OVESETUP_CONFIG_ADMIN_SETUP"
@@ -46,18 +51,6 @@ class Plugin(plugin.PluginBase):
         ].append(
             "QUESTION/2/OVESETUP_CONFIG_ADMIN_SETUP"
         )
-
-
-    @plugin.event(
-        stage=plugin.Stages.STAGE_INIT,
-    )
-    def _init(self):
-        self.environment[
-            osetupcons.CoreEnv.SETUP_ATTRS_MODULES
-        ].append(
-            okkcons,
-        )
-
 
     @plugin.event(
         stage=plugin.Stages.STAGE_SETUP,


### PR DESCRIPTION
This patch removes is_secret annotation from
POSTGRES_PROVISIONING_ENABLED that resulted in tons of tracebacks when
trying to register attributes at STAGE_BOOT

Signed-off-by: Artur Socha <asocha@redhat.com>
