### PR TITLE
Save keycloak ovirt admin usernames in postinstall

### DIFF
--- a/packaging/setup/ovirt_engine_setup/keycloak/constants.py
+++ b/packaging/setup/ovirt_engine_setup/keycloak/constants.py
@@ -156,6 +156,18 @@ class ConfigEnv(object):
     def ADMIN_PASSWORD(self):
         return 'OVESETUP_KEYCLOAK_CONFIG/adminPassword'
 
+    @osetupattrs(
+        postinstallfile=True,
+    )
+    def OVIRT_ADMIN_USER(self):
+        return 'OVESETUP_KEYCLOAK_CONFIG/ovirtAdminUser'
+
+    @osetupattrs(
+        postinstallfile=True,
+    )
+    def OVIRT_ADMIN_USER_WITH_PROFILE(self):
+        return 'OVESETUP_KEYCLOAK_CONFIG/ovirtAdminUserWithProfile'
+
     KEYCLOAK_ADD_USER_SCRIPT = 'OVESETUP_KEYCLOAK_CONFIG/addUserKeycloakScript'
     KEYCLOAK_CLI_ADMIN_SCRIPT = 'OVESETUP_KEYCLOAK_CONFIG/kcadmScript'
     KEYCLOAK_WRAPPER_SCRIPT = 'OVESETUP_KEYCLOAK_CONFIG/kkWrapperScript'

--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/core/ovirt_internal.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/core/ovirt_internal.py
@@ -129,7 +129,9 @@ class Plugin(plugin.PluginBase):
                     description=f"Grafana '{role}' role"
                 )
             self._assign_role_to_user(
-                username=okkcons.Const.OVIRT_ADMIN_USER,
+                username=self.environment[
+                    okkcons.ConfigEnv.OVIRT_ADMIN_USER
+                ],
                 role_name=okkcons.Const.GRAFANA_ADMIN_ROLE
             )
             self.logger.info('Done with setting up Keycloak for Ovirt Engine')
@@ -413,7 +415,8 @@ class Plugin(plugin.PluginBase):
         return group_id
 
     def _setup_internal_admin_user(self, password, administrator_group_id):
-        admin_user_id = self._get_user_id(okkcons.Const.OVIRT_ADMIN_USER)
+        ovirt_admin_user = self.environment[okkcons.ConfigEnv.OVIRT_ADMIN_USER]
+        admin_user_id = self._get_user_id(ovirt_admin_user)
         if admin_user_id is None:
             rc, stdout, stderr = self.execute(
                 (
@@ -423,7 +426,7 @@ class Plugin(plugin.PluginBase):
                     'create',
                     'users',
                     '-r', okkcons.Const.KEYCLOAK_INTERNAL_REALM,
-                    '-s', f'username={okkcons.Const.OVIRT_ADMIN_USER}',
+                    '-s', f'username={ovirt_admin_user}',
                     '-s', f'email={okkcons.Const.OVIRT_ADMIN_USER_EMAIL}',
                     '-s', 'enabled=true',
                     '-i',
@@ -445,7 +448,7 @@ class Plugin(plugin.PluginBase):
                 ],
                 'set-password',
                 '-r', okkcons.Const.KEYCLOAK_INTERNAL_REALM,
-                '--username', okkcons.Const.OVIRT_ADMIN_USER,
+                '--username', ovirt_admin_user,
             ),
             envAppend=envs,
         )
@@ -669,7 +672,7 @@ class Plugin(plugin.PluginBase):
                 "Please use the user '{user}' and password specified in "
                 "order to login using Keycloak SSO"
             ).format(
-                user=okkcons.Const.OVIRT_ADMIN_USER,
+                user=self.environment[okkcons.ConfigEnv.OVIRT_ADMIN_USER],
                 keycloakadmin=self.environment[
                     oenginecons.ConfigEnv.ADMIN_USER
                 ].rsplit('@', 1)[0],

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/config/keycloak.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/config/keycloak.py
@@ -52,6 +52,21 @@ class Plugin(plugin.PluginBase):
             None,
         )
 
+        self.environment.setdefault(
+            okkcons.ConfigEnv.OVIRT_ADMIN_USER,
+            okkcons.Const.OVIRT_ADMIN_USER
+        )
+
+        keycloak_admin_with_profile = \
+            '{user}@{profile}'.format(
+                user=okkcons.Const.OVIRT_ADMIN_USER,
+                profile=okkcons.Const.OVIRT_ENGINE_KEYCLOAK_SSO_PROFILE,
+            )
+        self.environment.setdefault(
+            okkcons.ConfigEnv.OVIRT_ADMIN_USER_WITH_PROFILE,
+            keycloak_admin_with_profile
+        )
+
     @plugin.event(
         stage=plugin.Stages.STAGE_CUSTOMIZATION,
         name=okkcons.Stages.KEYCLOAK_CREDENTIALS_SETUP,
@@ -100,15 +115,11 @@ class Plugin(plugin.PluginBase):
                 ),
             )
         self.environment[okkcons.ConfigEnv.ADMIN_PASSWORD] = password
-        keycloak_ovn_admin = \
-            '{user}@{profile}'.format(
-                user=okkcons.Const.OVIRT_ADMIN_USER,
-                profile=okkcons.Const.OVIRT_ENGINE_KEYCLOAK_SSO_PROFILE,
-            )
         self.environment[
             oengcommcons.KeycloakEnv.KEYCLOAK_OVIRT_ADMIN_USER
-        ] = keycloak_ovn_admin
-
+        ] = self.environment[
+            okkcons.ConfigEnv.OVIRT_ADMIN_USER_WITH_PROFILE
+        ]
         self.environment[
             oengcommcons.KeycloakEnv.KEYCLOAK_OVIRT_ADMIN_PASSWD
         ] = password


### PR DESCRIPTION
Both ovirt 'admin' and ovirt 'admin with profile' user names are saved
in postinstall as follows:

OVESETUP_KEYCLOAK_CONFIG/ovirtAdminUser=str:admin@ovirt
OVESETUP_KEYCLOAK_CONFIG/ovirtAdminUserWithProfile=str:admin@ovirt@internalsso

Signed-off-by: Artur Socha <asocha@redhat.com>
