### PR TITLE
Always set engine KEYCLOAK_ENABLED

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/core/misc.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/core/misc.py
@@ -103,8 +103,8 @@ class Plugin(plugin.PluginBase):
                     default=True,
                 )
 
-            self.environment[oengcommcons.KeycloakEnv.KEYCLOAK_ENABLED] = \
-                self.environment[okkcons.CoreEnv.ENABLE]
+        self.environment[oengcommcons.KeycloakEnv.KEYCLOAK_ENABLED] = \
+            self.environment[okkcons.CoreEnv.ENABLE]
 
 
 # vim: expandtab tabstop=4 shiftwidth=4


### PR DESCRIPTION
So that if ours ENABLED is set in the answer file and we do not ask,
the engine plugins know.