### PR TITLE
Fix keycloak db cleanup on engine-cleanup

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/db/pgpass.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/db/pgpass.py
@@ -46,7 +46,6 @@ class Plugin(plugin.PluginBase):
         ),
         condition=lambda self: (
             self.environment[okkcons.CoreEnv.ENABLE] and
-            self.environment[okkcons.DBEnv.NEW_DATABASE] and
             self.environment[okkcons.DBEnv.PASSWORD] is not None
         ),
     )


### PR DESCRIPTION
NEW_DATABASE constraint for pgpass creation here was wrong because
cleanup requires it. Removed as a result.

This patch is a requirement for https://github.com/oVirt/ovirt-engine/pull/251

Signed-off-by: Artur Socha <asocha@redhat.com>