### PR TITLE
spec: package byte-compiled python files

### DIFF
--- a/ovirt-engine-keycloak.spec.in
+++ b/ovirt-engine-keycloak.spec.in
@@ -73,6 +73,12 @@ make %{make_common_opts}
 rm -fr "%{buildroot}"
 make %{make_common_opts} install DESTDIR=%{buildroot}
 
+# Compile python files
+%py_byte_compile %{__python3} %{buildroot}%{_libexecdir}/
+%py_byte_compile %{__python3} %{buildroot}%{ovirt_engine_data}/
+
+%{__python3} -m compileall -f -q -d "%{python3_sitelib}" "%{buildroot}%{python3_sitelib}"
+%{__python3} -O -m compileall -f -q -d "%{python3_sitelib}" "%{buildroot}%{python3_sitelib}"
 
 # /var creation
 install -dm 755 "%{buildroot}/%{_localstatedir}/lib/ovirt-engine-keycloak"


### PR DESCRIPTION
So that they are included in the package and not auto-generated
on-the-fly.

Related-To: https://bugzilla.redhat.com/1043397