### PR TITLE
packaging: Allow custom DB credentials

### DIFF
--- a/packaging/setup/ovirt_engine_setup/keycloak/constants.py
+++ b/packaging/setup/ovirt_engine_setup/keycloak/constants.py
@@ -363,6 +363,8 @@ class Stages(object):
     KEYCLOAK_CREDENTIALS_SETUP = 'osetup.keycloak.config.credentials'
     DB_CREDENTIALS_AVAILABLE = 'osetup.keycloak.db.connection.credentials'
     DB_CONNECTION_SETUP = 'osetup.keycloak.db.connection.setup'
+    DB_CONNECTION_CUSTOMIZATION = \
+        'osetup.keycloak.db.connection.customization'
     ENGINE_DB_CONNECTION_AVAILABLE = \
         'osetup.keycloak.engine.db.connection.available'
     DB_PROVISIONING_CUSTOMIZATION = 'osetup.keycloak.db.provisioning.customization'

--- a/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/db/connection.py
+++ b/packaging/setup/plugins/ovirt-engine-common/ovirt-engine-keycloak/db/connection.py
@@ -99,16 +99,7 @@ class Plugin(plugin.PluginBase):
         self.environment[okkcons.DBEnv.NEED_DBMSUPGRADE] = False
 
     @plugin.event(
-        stage=plugin.Stages.STAGE_CUSTOMIZATION,
-        after=(
-            okkcons.Stages.CORE_ENABLE,
-        ),
-        before=(
-            okkcons.Stages.DB_CONNECTION_SETUP,
-        ),
-        condition=lambda self: (
-            self.environment[oengcommcons.KeycloakEnv.ENABLE]
-        ),
+        stage=plugin.Stages.STAGE_SETUP,
     )
     def _commands(self):
         dbovirtutils = database.OvirtUtils(
@@ -118,17 +109,11 @@ class Plugin(plugin.PluginBase):
         dbovirtutils.detectCommands()
 
     @plugin.event(
-        stage=plugin.Stages.STAGE_CUSTOMIZATION,
+        stage=plugin.Stages.STAGE_SETUP,
         name=okkcons.Stages.DB_CONNECTION_SETUP,
-        after=(
-            okkcons.Stages.CORE_ENABLE,
-        ),
         condition=lambda self: (
-            self.environment[oengcommcons.KeycloakEnv.ENABLE] and
-            (
-                self.environment[osetupcons.CoreEnv.ACTION]
-                != osetupcons.Const.ACTION_PROVISIONDB
-            )
+            self.environment[osetupcons.CoreEnv.ACTION]
+            != osetupcons.Const.ACTION_PROVISIONDB
         ),
     )
     def _setup_connection(self):

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/db/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/db/__init__.py
@@ -1,0 +1,23 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""Keycloak database plugins."""
+
+
+from otopi import util
+
+from . import connection
+
+
+@util.export
+def createPlugins(context):
+    connection.Plugin(context=context)
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/db/connection.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/db/connection.py
@@ -1,0 +1,55 @@
+#
+# ovirt-engine-setup -- ovirt engine setup
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+"""Keycloak connection plugin."""
+
+
+from otopi import plugin
+from otopi import util
+
+from ovirt_engine_setup.keycloak import constants as okkcons
+from ovirt_engine_setup.engine import constants as oenginecons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+from ovirt_engine_setup.engine_common import database
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """Keycloak connection plugin."""
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_CUSTOMIZATION,
+        name=okkcons.Stages.DB_CONNECTION_CUSTOMIZATION,
+        before=(
+            oengcommcons.Stages.DB_OWNERS_CONNECTIONS_CUSTOMIZED,
+        ),
+        after=(
+            oengcommcons.Stages.DIALOG_TITLES_S_DATABASE,
+        ),
+        condition=lambda self: (
+            self.environment[oenginecons.CoreEnv.ENABLE] and
+            self.environment[oengcommcons.KeycloakEnv.ENABLE]
+        )
+    )
+    def _customization(self):
+        database.OvirtUtils(
+            plugin=self,
+            dbenvkeys=okkcons.Const.KEYCLOAK_DB_ENV_KEYS,
+        ).getCredentials(
+            name='Keycloak',
+            queryprefix='OVESETUP_KEYCLOAK_DB_',
+            defaultdbenvkeys=okkcons.Const.DEFAULT_KEYCLOAK_DB_ENV_KEYS,
+            show_create_msg=True,
+        )
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/provisioning/postgres.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/provisioning/postgres.py
@@ -54,14 +54,11 @@ class Plugin(plugin.PluginBase):
         )
 
     @plugin.event(
-        stage=plugin.Stages.STAGE_CUSTOMIZATION,
+        stage=plugin.Stages.STAGE_SETUP,
         after=(
             okkcons.Stages.DB_CONNECTION_SETUP,
         ),
-        condition=lambda self: (
-            self.environment[oengcommcons.KeycloakEnv.ENABLE] and
-            self.environment[okkcons.DBEnv.NEW_DATABASE]
-        ),
+        condition=lambda self: self.environment[okkcons.DBEnv.NEW_DATABASE],
     )
     def _setup(self):
         self._provisioning.detectCommands()
@@ -72,6 +69,10 @@ class Plugin(plugin.PluginBase):
         name=okkcons.Stages.DB_PROVISIONING_CUSTOMIZATION,
         after=(
             oengcommcons.Stages.DIALOG_TITLES_S_DATABASE,
+        ),
+        before=(
+            oengcommcons.Stages.DIALOG_TITLES_E_DATABASE,
+            okkcons.Stages.DB_CONNECTION_CUSTOMIZATION,
         ),
         condition=lambda self: (
             self._enabled and
@@ -127,6 +128,8 @@ class Plugin(plugin.PluginBase):
         self.environment[
             okkcons.ProvisioningEnv.POSTGRES_PROVISIONING_ENABLED
         ] = self._enabled = enabled
+        if self._enabled:
+            self._provisioning.applyEnvironment()
 
     @plugin.event(
         stage=plugin.Stages.STAGE_CUSTOMIZATION,
@@ -168,7 +171,6 @@ class Plugin(plugin.PluginBase):
         )
     )
     def _misc(self):
-        self._provisioning.applyEnvironment()
         self._provisioning.provision()
 
     @plugin.event(


### PR DESCRIPTION
Without this patch, only Local/Automatic DB provisioning works.
Other options are allowed by the code, but fail due to missing
credentials.

Fix this by asking for credentials if not using automatic provisioning.

Bug-Url: https://bugzilla.redhat.com/2116853