### PR TITLE
Fixed internal server error when enabling keycloak on existing installation

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/config/keycloak.py
+++ b/packaging/setup/plugins/ovirt-engine-setup/ovirt-engine-keycloak/config/keycloak.py
@@ -79,22 +79,33 @@ class Plugin(plugin.PluginBase):
     )
     def _setup_keycloak_ovirt_admin_credentials(self):
         password = None
-        if self.environment[oenginecons.ConfigEnv.ADMIN_PASSWORD] is not None:
-            use_engine_admin_password = dialog.queryBoolean(
+        if self.environment[oenginecons.ConfigEnv.ADMIN_PASSWORD] is None:
+            engine_admin_password = dialog.queryPassword(
                 dialog=self.dialog,
-                name='KEYCLOAK_USE_ENGINE_ADMIN_PASSWORD',
+                logger=self.logger,
+                env=self.environment,
+                key=oengcommcons.ConfigEnv.ADMIN_PASSWORD,
                 note=_(
-                    f"Use Engine admin password as initial "
-                    f"keycloak admin password "
-                    f"(@VALUES@) [@DEFAULT@]: "
+                    f'Engine [admin] password: '
                 ),
-                prompt=True,
-                default=True
             )
-            if use_engine_admin_password:
-                password = self.environment[
-                    oenginecons.ConfigEnv.ADMIN_PASSWORD
-                ]
+            self.environment[oengcommcons.ConfigEnv.ADMIN_PASSWORD] = engine_admin_password
+
+        use_engine_admin_password = dialog.queryBoolean(
+            dialog=self.dialog,
+            name='KEYCLOAK_USE_ENGINE_ADMIN_PASSWORD',
+            note=_(
+                f"Use Engine admin password as initial "
+                f"keycloak admin password "
+                f"(@VALUES@) [@DEFAULT@]: "
+            ),
+            prompt=True,
+            default=True
+        )
+        if use_engine_admin_password:
+            password = self.environment[
+                oenginecons.ConfigEnv.ADMIN_PASSWORD
+            ]
 
         if password is None:
             password = dialog.queryPassword(


### PR DESCRIPTION
Fixes https://github.com/oVirt/ovirt-engine-keycloak/issues/61

When you rerun engine-setup to activate Keycloak, it can't find the OVESETUP_CONFIG/adminPassword value in the environmental variables. This becomes a problem when you're setting up Keycloak alone because it needs that password to correctly finish the setup. Since we can't fetch the password in plain text from anywhere, we ask the user to enter the engine password so the setup can complete successfully.

Note: This is not an issue when setting up a fresh installation with engine-setup (and immediately activating keycloak), because the password is stored in the environmental variables.