### PR TITLE
Support for OpenIDC and Keycloak has been added for the ovirt-engine-rename

### DIFF
--- a/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine-keycloak/apache/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine-keycloak/apache/__init__.py
@@ -1,0 +1,21 @@
+#
+# ovirt-engine-rename -- ovirt engine rename
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+from otopi import util
+
+
+from . import internalsso
+
+
+@util.export
+def createPlugins(context):
+    internalsso.Plugin(context=context)
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine-keycloak/apache/internalsso.py
+++ b/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine-keycloak/apache/internalsso.py
@@ -1,0 +1,93 @@
+#
+# ovirt-engine-rename -- ovirt engine rename
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+"""keycloak httpd internal sso openidc config plugin."""
+
+import gettext
+
+from otopi import constants as otopicons
+from otopi import filetransaction
+from otopi import plugin
+from otopi import util
+from ovirt_engine_setup import constants as osetupcons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+from ovirt_engine_setup.keycloak import constants as okkcons
+import re
+
+
+PATTERNS = [
+    r'(^\s+OIDCProviderMetadataURL https://).+(\/ovirt-engine.*)',
+    r'(^\s+OIDCRedirectURI https:\/\/).+(\/ovirt-engine.*)',
+    r'(^\s+OIDCDefaultURL https:\/\/).+(\/ovirt-engine.*)',
+    r'(^\s+OIDCOAuthIntrospectionEndpoint https:\/\/).+(\/ovirt-engine.*)'
+]
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-rename')
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """keycloak httpd internal sso openidc config plugin."""
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_SETUP,
+    )
+    def _setup(self):
+        self.environment[
+            osetupcons.RenameEnv.FILES_TO_BE_MODIFIED
+        ].append(okkcons.FileLocations.HTTPD_CONF_OVIRT_ENGINE_INTERNAL_SSO_OPENIDC)
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_MISC,
+        condition=lambda self: (
+                self.environment[oengcommcons.KeycloakEnv.ENABLE]
+        )
+    )
+    def _internalsso_reconfigure(self):
+        """
+        Configuring parameters (see PATTERNS) in internalsso-openidc.conf with new FQDN
+        """
+        config_path = okkcons.FileLocations.HTTPD_CONF_OVIRT_ENGINE_INTERNAL_SSO_OPENIDC
+
+        REPLACEMENT = r'\g<1>{host}\g<2>'.format(
+            host=self.environment[osetupcons.RenameEnv.FQDN]
+        )
+
+        try:
+            with open(config_path, 'r') as file:
+                content = file.read()
+
+            for pattern in PATTERNS:
+                content = re.sub(
+                    pattern=pattern,
+                    repl=REPLACEMENT,
+                    string=content,
+                    flags=re.MULTILINE
+                )
+
+            self.environment[otopicons.CoreEnv.MAIN_TRANSACTION].append(
+                filetransaction.FileTransaction(
+                    name=config_path,
+                    content=content,
+                    modifiedList=self.environment[
+                        otopicons.CoreEnv.MODIFIED_FILES
+                    ],
+                )
+            )
+
+        except Exception as e:
+            raise RuntimeError(
+                _(f"Failed to update configuration file '{config_path}': {str(e)}")
+            )
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine-keycloak/keycloak/__init__.py
+++ b/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine-keycloak/keycloak/__init__.py
@@ -1,0 +1,21 @@
+#
+# ovirt-engine-rename -- ovirt engine rename
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+
+from otopi import util
+
+
+from . import client
+
+
+@util.export
+def createPlugins(context):
+    client.Plugin(context=context)
+
+
+# vim: expandtab tabstop=4 shiftwidth=4

--- a/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine-keycloak/keycloak/client.py
+++ b/packaging/setup/plugins/ovirt-engine-rename/ovirt-engine-keycloak/keycloak/client.py
@@ -1,0 +1,136 @@
+#
+# ovirt-engine-rename -- ovirt engine rename
+#
+# Copyright oVirt Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+"""keycloak client plugin."""
+
+import gettext
+
+from otopi import plugin
+from otopi import util
+from ovirt_engine_setup import constants as osetupcons
+from ovirt_engine_setup.engine_common import constants as oengcommcons
+from ovirt_engine_setup.keycloak import constants as okkcons
+from ovirt_engine_setup.engine_common import database
+
+
+def _(m):
+    return gettext.dgettext(message=m, domain='ovirt-engine-rename')
+
+
+@util.export
+class Plugin(plugin.PluginBase):
+    """keycloak client plugin."""
+
+    def __init__(self, context):
+        super(Plugin, self).__init__(context=context)
+
+    @plugin.event(
+        stage=plugin.Stages.STAGE_MISC,
+        after=(
+                oengcommcons.Stages.DB_CONNECTION_AVAILABLE,
+        )
+    )
+    def _update_client(self):
+        """
+        Update Root URL, Valid Redirect URIs, Base URL, Admin URL and Web Origins
+        for ovirt-engine-internal client
+        """
+        self.logger.info(
+            _(f"Update Keycloak client: {okkcons.Const.KEYCLOAK_INTERNAL_CLIENT_NAME}")
+        )
+
+        statement = database.Statement(
+            environment=self.environment,
+            dbenvkeys=okkcons.Const.KEYCLOAK_DB_ENV_KEYS,
+        )
+
+        try:
+            # Get Client ID
+            client_id = statement.execute(
+                statement="""
+                    SELECT id FROM public.client
+                    WHERE client_id = %(client_name)s;
+                """,
+                args=dict(
+                    client_name=okkcons.Const.KEYCLOAK_INTERNAL_CLIENT_NAME,
+                ),
+                ownConnection=True,
+                transaction=False,
+            )
+
+            if not client_id:
+                self.logger.warning(
+                    _("Keycloak client not found")
+                )
+                return
+
+            client_id = client_id[0].get('id')
+            base_url = f'https://{self.environment[osetupcons.RenameEnv.FQDN]}'
+
+            # Update client table
+            statement.execute(
+                statement="""
+                    UPDATE public.client
+                    SET
+                        root_url =  %(url)s,
+                        base_url =  %(url)s,
+                        management_url =  %(url)s
+                    WHERE id = %(client_id)s;
+                """,
+                args=dict(
+                    url=base_url,
+                    client_id=client_id
+                ),
+                ownConnection=True,
+                transaction=False,
+            )
+
+            # Update web_origins table
+            statement.execute(
+                statement="""
+                    UPDATE public.web_origins
+                    SET
+                        value = %(url)s
+                    WHERE client_id = %(client_id)s;
+                """,
+                args=dict(
+                    url=base_url,
+                    client_id=client_id
+                ),
+                ownConnection=True,
+                transaction=False,
+            )
+
+            # Update redirect_uris table
+            statement.execute(
+                statement="""
+                    DELETE FROM public.redirect_uris
+                    WHERE client_id = %(client_id)s;
+
+                    INSERT INTO public.redirect_uris (client_id, value)
+                    VALUES (%(client_id)s, %(uri)s);
+                """,
+                args=dict(
+                    uri=f'{base_url}*',
+                    client_id=client_id
+                ),
+                ownConnection=True,
+                transaction=False,
+            )
+
+            self.logger.info(
+                _("Keycloak client updated successfully")
+            )
+
+        except Exception as e:
+            self.logger.error(
+                _(f"Failed to update Keycloak client: {str(e)}")
+            )
+
+
+# vim: expandtab tabstop=4 shiftwidth=4


### PR DESCRIPTION
Support for OpenIDC and Keycloak has been added for the ovirt-engine-rename

##  Changes introduced with this PR

This PR adds ovirt-engine-rename's ability to manage Apache settings in terms of configuring OpenIDC and changing ovirt-engine-internal client settings in Keycloak

## How to use

- Install Manager as standalone + Keycloak (for HostedEngine also works)
- Login to Manager by ssh
- Run `/usr/share/ovirt-engine/setup/bin/ovirt-engine-rename --newname=NEW.FQDN.DOMAIN` to change FQDN

## Expected behavior:

Users can be successfully authorised to Admin and VM portals


## Current behavior:

Without this PR, users will get an error when trying to access the Admin and VM portals::
```
Internal Server Error

The server encountered an internal error or misconfiguration and was unable to complete your request.

Please contact the server administrator at root@localhost to inform them of the time this error occurred, and the actions you performed just before this error.

More information about this error may be available in the server error log.
```


## Are you the owner of the code you are sending in, or do you have permission of the owner?

y